### PR TITLE
Replace defunct VAR with active United Aviate Academy VAR

### DIFF
--- a/airlinecodes.txt
+++ b/airlinecodes.txt
@@ -6214,7 +6214,7 @@ VAL,Voyageur Airways,VOYAGEUR,Canada
 VAM,Ameravia,AMERAVIA,Uruguay
 VAN,Caravan Air,CAMEL,Mauritania
 VAP,Phuket Air,PHUKET AIR,Thailand
-VAR,Veca Airlines,VECA,El Salvador
+VAR,United Aviate Academy,VARNEY,United States
 VAS,ATRAN Cargo Airlines,ATRAN,Russian Federation
 VAT,Visionair,VISIONAIR,Ireland
 VAU,V Australia Airlines,,Australia


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Veca_Airlines - "As of January 18, 2017 VECA airlines suspended operations due to financial problems."

https://www.faa.gov/documentLibrary/media/Notice/WOCC_GENOT_VARNEY_VAR.pdf - 
> SUBJECT: ICAO THREE LETTER DESIGNATOR (3LD) “VAR” AND
ASSOCIATED CALL SIGN “VARNEY”